### PR TITLE
keying off snippet flag before deciding to use bem emmett

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "keybindings": [{
             "command": "extension.bemExpand",
             "key": "tab",
-            "when": "config.emmet.triggerExpansionOnTab && editorTextFocus && !editorHasMultipleSelections && !editorHasSelection && !editorReadonly && !editorTabMovesFocus"
+            "when": "config.emmet.triggerExpansionOnTab && editorTextFocus && !editorHasMultipleSelections && !editorHasSelection && !editorReadonly && !editorTabMovesFocus && !suggestWidgetVisible"
         }]
     },
     "scripts": {


### PR DESCRIPTION
fixes bem-expand from blocking snippet completion on tab